### PR TITLE
Add dual cannon firing to WebXR demo

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -37,6 +37,11 @@
 			</div>
 
 			<div>
+				Aim with headset or mouse. Press Z to fire left cannon, X for right
+				cannon.
+			</div>
+
+			<div>
 				Copyright © Meta Platforms, Inc |
 
 				<a href="https://opensource.fb.com/legal/terms/">Terms</a>&nbsp;|&nbsp;


### PR DESCRIPTION
## Summary
- add head-tracked dual cannons that fire toward a shared crosshair
- map left/right triggers or Z/X keys to fire each cannon independently
- show new keyboard controls in the overlay

## Testing
- `npm run format`
- `npx prettier --write src/index.js`
- `npx prettier --write src/index.html`
- `npm run dev`
- `npm run test:puppeteer` *(fails: libatk-1.0.so.0: cannot open shared object file)*

------
https://chatgpt.com/codex/tasks/task_e_68bc0ccb4d58832fa74cc28a652d5e41