### PR TITLE
Add transparent explosion effect when enemies die

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -21,6 +21,10 @@ let bulletGeo = null;
 let bulletMat = null;
 let laserMat = null;
 const bullets = [];
+let explosionGroup = null;
+let explosionGeo = null;
+let explosionMat = null;
+const explosions = [];
 let audioListener = null;
 let cannonBuffer = null;
 let laserBuffer = null;
@@ -123,79 +127,91 @@ function setupScene({ scene, camera }) {
 	playerRotText.color = 0xffffff;
 	playerRotText.anchorX = 'left';
 	playerRotText.anchorY = 'top';
-        playerRotText.position.set(-0.6, 0.37, -1.2);
-        playerRotText.renderOrder = 1000;
-        playerRotText.material.depthTest = false;
-        playerRotText.material.depthWrite = false;
-        camera.add(playerRotText);
+	playerRotText.position.set(-0.6, 0.37, -1.2);
+	playerRotText.renderOrder = 1000;
+	playerRotText.material.depthTest = false;
+	playerRotText.material.depthWrite = false;
+	camera.add(playerRotText);
 
-        // HUD: score display
-        scoreText = new Text();
-        scoreText.text = 'Score: 0';
-        scoreText.fontSize = 0.06;
-        scoreText.color = 0x00ff00;
-        scoreText.anchorX = 'right';
-        scoreText.anchorY = 'top';
-        scoreText.position.set(0.6, 0.43, -1.2);
-        scoreText.renderOrder = 1000;
-        scoreText.material.depthTest = false;
-        scoreText.material.depthWrite = false;
-        camera.add(scoreText);
+	// HUD: score display
+	scoreText = new Text();
+	scoreText.text = 'Score: 0';
+	scoreText.fontSize = 0.06;
+	scoreText.color = 0x00ff00;
+	scoreText.anchorX = 'right';
+	scoreText.anchorY = 'top';
+	scoreText.position.set(0.6, 0.43, -1.2);
+	scoreText.renderOrder = 1000;
+	scoreText.material.depthTest = false;
+	scoreText.material.depthWrite = false;
+	camera.add(scoreText);
 
 	// Bullet prototype/shared
-        bulletGeo = new THREE.SphereGeometry(BULLET_RADIUS, 16, 12);
-        bulletMat = new THREE.MeshStandardMaterial({ color: 0xffaa00 });
-        laserMat = new THREE.MeshStandardMaterial({
-                color: 0x00ffff,
-                emissive: 0x00ffff,
-        });
-        bulletGroup = new THREE.Group();
-        scene.add(bulletGroup);
+	bulletGeo = new THREE.SphereGeometry(BULLET_RADIUS, 16, 12);
+	bulletMat = new THREE.MeshStandardMaterial({ color: 0xffaa00 });
+	laserMat = new THREE.MeshStandardMaterial({
+		color: 0x00ffff,
+		emissive: 0x00ffff,
+	});
+	bulletGroup = new THREE.Group();
+	scene.add(bulletGroup);
 
-// Enemy placeholders: shared geometry/materials and group
-const enemyGeo = new THREE.IcosahedronGeometry(ENEMY_RADIUS, 0);
-const enemyMats = [
-new THREE.MeshStandardMaterial({
-color: 0xff3333,
-metalness: 0.1,
-roughness: 0.8,
-}),
-new THREE.MeshStandardMaterial({
-color: 0x3333ff,
-metalness: 0.1,
-roughness: 0.8,
-}),
-];
-const enemyGroup = new THREE.Group();
-enemyGroup.name = 'enemies';
-scene.add(enemyGroup);
-// Stash factory and group for use in onFrame
-bulletGroup.userData.enemyGeo = enemyGeo;
-bulletGroup.userData.enemyMats = enemyMats;
-bulletGroup.userData.enemyGroup = enemyGroup;
+	// Enemy placeholders: shared geometry/materials and group
+	const enemyGeo = new THREE.IcosahedronGeometry(ENEMY_RADIUS, 0);
+	const enemyMats = [
+		new THREE.MeshStandardMaterial({
+			color: 0xff3333,
+			metalness: 0.1,
+			roughness: 0.8,
+		}),
+		new THREE.MeshStandardMaterial({
+			color: 0x3333ff,
+			metalness: 0.1,
+			roughness: 0.8,
+		}),
+	];
+	const enemyGroup = new THREE.Group();
+	enemyGroup.name = 'enemies';
+	scene.add(enemyGroup);
+	// Stash factory and group for use in onFrame
+	bulletGroup.userData.enemyGeo = enemyGeo;
+	bulletGroup.userData.enemyMats = enemyMats;
+	bulletGroup.userData.enemyGroup = enemyGroup;
+
+	// Explosion placeholders
+	explosionGeo = new THREE.SphereGeometry(1, 16, 12);
+	explosionMat = new THREE.MeshBasicMaterial({
+		color: 0xff8800,
+		transparent: true,
+		opacity: 0.7,
+		blending: THREE.AdditiveBlending,
+		depthWrite: false,
+	});
+	explosionGroup = new THREE.Group();
+	scene.add(explosionGroup);
 
 	// Audio: listener + load shot buffer (prefer shot1.mp3 with fallbacks)
 	audioListener = new THREE.AudioListener();
 	camera.add(audioListener);
-        const audioLoader = new THREE.AudioLoader();
-        const tryLoad = (url, next) => {
-                audioLoader.load(
-                        url,
-                        (buffer) => {
-                                cannonBuffer = buffer;
-                        },
-                        undefined,
-                        () => {
-                                if (next) next();
-                        },
-                );
-        };
-        tryLoad('assets/shot1.mp3', () =>
-                tryLoad('assets/big_caliber_gunshot-1757083126996.mp3'),
-        );
-        audioLoader.load('assets/laser.ogg', (buffer) => {
-                laserBuffer = buffer;
-        });
+	const audioLoader = new THREE.AudioLoader();
+	const tryLoad = (url, next) => {
+		audioLoader.load(
+			url,
+			(buffer) => {
+				cannonBuffer = buffer;
+			},
+			undefined,
+			() => {
+				if (next) next();
+			},
+		);
+	};
+	tryLoad('assets/shot1.mp3', () =>
+		tryLoad('assets/big_caliber_gunshot-1757083126996.mp3'),
+	);
+	audioLoader.load('assets/laser.ogg', (buffer) => {
+		laserBuffer = buffer;
+	});
 }
 
 const DEADZONE = 0.15;
@@ -218,17 +234,19 @@ const ENEMY_Y_OFFSET = 6.0; // spawn height above player
 const ENEMY_AHEAD_MIN = 6.0; // min distance ahead of player
 const ENEMY_AHEAD_MAX = 12.0; // max distance ahead of player
 let enemySpawnTimer = 0;
+const EXPLOSION_TTL = 0.6; // seconds
+const EXPLOSION_GROWTH = 4; // scale units per second
 
 function onFrame(delta, _time, { controllers, camera, player }) {
-        if (scoreText) {
-                scoreText.text = `Score: ${score}`;
-                scoreText.sync();
-        }
-        // Update player position HUD
-        if (playerPosText && player) {
-                const p = new THREE.Vector3();
-                player.getWorldPosition(p);
-                playerPosText.text = `Player: x=${p.x.toFixed(2)} y=${p.y.toFixed(2)} z=${p.z.toFixed(2)}`;
+	if (scoreText) {
+		scoreText.text = `Score: ${score}`;
+		scoreText.sync();
+	}
+	// Update player position HUD
+	if (playerPosText && player) {
+		const p = new THREE.Vector3();
+		player.getWorldPosition(p);
+		playerPosText.text = `Player: x=${p.x.toFixed(2)} y=${p.y.toFixed(2)} z=${p.z.toFixed(2)}`;
 		playerPosText.sync();
 	}
 
@@ -310,125 +328,126 @@ function onFrame(delta, _time, { controllers, camera, player }) {
 	}
 
 	// Enemies: spawn, move, and handle bullet collisions
-const enemyGroup = bulletGroup?.userData?.enemyGroup;
-const enemyGeo = bulletGroup?.userData?.enemyGeo;
-const enemyMats = bulletGroup?.userData?.enemyMats;
-if (enemyGroup && enemyGeo && enemyMats) {
-    enemySpawnTimer += delta;
-    while (enemySpawnTimer >= ENEMY_SPAWN_INTERVAL) {
-        enemySpawnTimer -= ENEMY_SPAWN_INTERVAL;
-        
-        const ppos = new THREE.Vector3();
-        player.getWorldPosition(ppos);
-        const yaw = player.rotation.y;
-        const fwd = new THREE.Vector3(Math.sin(yaw), 0, -Math.cos(yaw));
-        const right = new THREE.Vector3(fwd.z, 0, -fwd.x).normalize();
-        const ahead =
-            ENEMY_AHEAD_MIN + Math.random() * (ENEMY_AHEAD_MAX - ENEMY_AHEAD_MIN);
-        const spreadRad = THREE.MathUtils.degToRad(ENEMY_SPREAD_DEG);
-        const ang = (Math.random() * 2 - 1) * spreadRad;
-        const lateral = Math.tan(ang) * ahead;
-        const start = ppos
-            .clone()
-            .addScaledVector(fwd, ahead)
-            .addScaledVector(right, lateral);
-        start.y = ppos.y + ENEMY_Y_OFFSET;
-        
-        const dir = ppos.clone().sub(start).normalize();
-        const mat = enemyMats[Math.floor(Math.random() * enemyMats.length)];
-        const enemy = new THREE.Mesh(enemyGeo, mat);
-        enemy.position.copy(start);
-        enemy.userData = {
-            vel: dir.multiplyScalar(ENEMY_SPEED),
-            hp: 1,
-            radius: ENEMY_RADIUS,
-        };
-        enemyGroup.add(enemy);
-    }
-}
+	const enemyGroup = bulletGroup?.userData?.enemyGroup;
+	const enemyGeo = bulletGroup?.userData?.enemyGeo;
+	const enemyMats = bulletGroup?.userData?.enemyMats;
+	if (enemyGroup && enemyGeo && enemyMats) {
+		enemySpawnTimer += delta;
+		while (enemySpawnTimer >= ENEMY_SPAWN_INTERVAL) {
+			enemySpawnTimer -= ENEMY_SPAWN_INTERVAL;
 
-		for (let i = enemyGroup.children.length - 1; i >= 0; i--) {
-			const e = enemyGroup.children[i];
-			e.position.addScaledVector(e.userData.vel, delta);
-			if (e.position.y < -2 || e.position.distanceTo(player.position) > 60) {
-				enemyGroup.remove(e);
+			const ppos = new THREE.Vector3();
+			player.getWorldPosition(ppos);
+			const yaw = player.rotation.y;
+			const fwd = new THREE.Vector3(Math.sin(yaw), 0, -Math.cos(yaw));
+			const right = new THREE.Vector3(fwd.z, 0, -fwd.x).normalize();
+			const ahead =
+				ENEMY_AHEAD_MIN + Math.random() * (ENEMY_AHEAD_MAX - ENEMY_AHEAD_MIN);
+			const spreadRad = THREE.MathUtils.degToRad(ENEMY_SPREAD_DEG);
+			const ang = (Math.random() * 2 - 1) * spreadRad;
+			const lateral = Math.tan(ang) * ahead;
+			const start = ppos
+				.clone()
+				.addScaledVector(fwd, ahead)
+				.addScaledVector(right, lateral);
+			start.y = ppos.y + ENEMY_Y_OFFSET;
+
+			const dir = ppos.clone().sub(start).normalize();
+			const mat = enemyMats[Math.floor(Math.random() * enemyMats.length)];
+			const enemy = new THREE.Mesh(enemyGeo, mat);
+			enemy.position.copy(start);
+			enemy.userData = {
+				vel: dir.multiplyScalar(ENEMY_SPEED),
+				hp: 1,
+				radius: ENEMY_RADIUS,
+			};
+			enemyGroup.add(enemy);
+		}
+	}
+
+	for (let i = enemyGroup.children.length - 1; i >= 0; i--) {
+		const e = enemyGroup.children[i];
+		e.position.addScaledVector(e.userData.vel, delta);
+		if (e.position.y < -2 || e.position.distanceTo(player.position) > 60) {
+			enemyGroup.remove(e);
+		}
+	}
+
+	for (let bi = bullets.length - 1; bi >= 0; bi--) {
+		const b = bullets[bi];
+		const bp = b.position;
+		let hit = null;
+		for (let ei = enemyGroup.children.length - 1; ei >= 0; ei--) {
+			const e = enemyGroup.children[ei];
+			const sumR = BULLET_RADIUS + (e.userData.radius ?? ENEMY_RADIUS);
+			if (bp.distanceTo(e.position) <= sumR) {
+				hit = e;
+				e.userData.hp -= 1;
+				break;
 			}
 		}
-
-		for (let bi = bullets.length - 1; bi >= 0; bi--) {
-			const b = bullets[bi];
-			const bp = b.position;
-			let hit = null;
-			for (let ei = enemyGroup.children.length - 1; ei >= 0; ei--) {
-				const e = enemyGroup.children[ei];
-				const sumR = BULLET_RADIUS + (e.userData.radius ?? ENEMY_RADIUS);
-				if (bp.distanceTo(e.position) <= sumR) {
-					hit = e;
-					e.userData.hp -= 1;
-					break;
-				}
+		if (hit) {
+			bulletGroup.remove(b);
+			bullets.splice(bi, 1);
+			if (hit.userData.hp <= 0) {
+				const ex = new THREE.Mesh(explosionGeo, explosionMat.clone());
+				ex.position.copy(hit.position);
+				ex.scale.setScalar(0.1);
+				ex.userData = {
+					ttl: EXPLOSION_TTL,
+					growth: EXPLOSION_GROWTH,
+				};
+				explosionGroup.add(ex);
+				explosions.push(ex);
+				enemyGroup.remove(hit);
+				score += 100;
 			}
-			if (hit) {
-				bulletGroup.remove(b);
-				bullets.splice(bi, 1);
-                                if (hit.userData.hp <= 0) {
-                                        enemyGroup.remove(hit);
-                                        score += 100;
-                                }
-                        }
-                }
-        }
-
+		}
+	}
 	const aimTarget = new THREE.Vector3();
-        if (crosshair) {
-                crosshair.getWorldPosition(aimTarget);
-                leftCannon?.lookAt(aimTarget);
-                rightCannon?.lookAt(aimTarget);
-        }
+	if (crosshair) {
+		crosshair.getWorldPosition(aimTarget);
+		leftCannon?.lookAt(aimTarget);
+		rightCannon?.lookAt(aimTarget);
+	}
 
-        // Weapon switching: BUTTON_1 (A/X) toggles per controller
-        const leftSwitchDown = !!(
-                controllers.left &&
-                controllers.left.gamepad &&
-                ((typeof controllers.left.gamepad.getButton === 'function' &&
-                        controllers.left.gamepad.getButton(XR_BUTTONS.BUTTON_1)) ||
-                        (typeof controllers.left.gamepad.getButtonPressed === 'function' &&
-                                controllers.left.gamepad.getButtonPressed(
-                                        XR_BUTTONS.BUTTON_1,
-                                )) ||
-                        (controllers.left.gamepad.gamepad &&
-                                controllers.left.gamepad.gamepad.buttons &&
-                                controllers.left.gamepad.gamepad.buttons[4]?.pressed))
-        );
-        const rightSwitchDown = !!(
-                controllers.right &&
-                controllers.right.gamepad &&
-                ((typeof controllers.right.gamepad.getButton === 'function' &&
-                        controllers.right.gamepad.getButton(XR_BUTTONS.BUTTON_1)) ||
-                        (typeof controllers.right.gamepad.getButtonPressed === 'function' &&
-                                controllers.right.gamepad.getButtonPressed(
-                                        XR_BUTTONS.BUTTON_1,
-                                )) ||
-                        (controllers.right.gamepad.gamepad &&
-                                controllers.right.gamepad.gamepad.buttons &&
-                                controllers.right.gamepad.gamepad.buttons[4]?.pressed))
-        );
-        if (leftSwitchDown && !prevLeftSwitch) {
-                weaponType.left =
-                        weaponType.left === 'cannon' ? 'laser' : 'cannon';
-        }
-        if (rightSwitchDown && !prevRightSwitch) {
-                weaponType.right =
-                        weaponType.right === 'cannon' ? 'laser' : 'cannon';
-        }
-        prevLeftSwitch = leftSwitchDown;
-        prevRightSwitch = rightSwitchDown;
+	// Weapon switching: BUTTON_1 (A/X) toggles per controller
+	const leftSwitchDown = !!(
+		controllers.left &&
+		controllers.left.gamepad &&
+		((typeof controllers.left.gamepad.getButton === 'function' &&
+			controllers.left.gamepad.getButton(XR_BUTTONS.BUTTON_1)) ||
+			(typeof controllers.left.gamepad.getButtonPressed === 'function' &&
+				controllers.left.gamepad.getButtonPressed(XR_BUTTONS.BUTTON_1)) ||
+			(controllers.left.gamepad.gamepad &&
+				controllers.left.gamepad.gamepad.buttons &&
+				controllers.left.gamepad.gamepad.buttons[4]?.pressed))
+	);
+	const rightSwitchDown = !!(
+		controllers.right &&
+		controllers.right.gamepad &&
+		((typeof controllers.right.gamepad.getButton === 'function' &&
+			controllers.right.gamepad.getButton(XR_BUTTONS.BUTTON_1)) ||
+			(typeof controllers.right.gamepad.getButtonPressed === 'function' &&
+				controllers.right.gamepad.getButtonPressed(XR_BUTTONS.BUTTON_1)) ||
+			(controllers.right.gamepad.gamepad &&
+				controllers.right.gamepad.gamepad.buttons &&
+				controllers.right.gamepad.gamepad.buttons[4]?.pressed))
+	);
+	if (leftSwitchDown && !prevLeftSwitch) {
+		weaponType.left = weaponType.left === 'cannon' ? 'laser' : 'cannon';
+	}
+	if (rightSwitchDown && !prevRightSwitch) {
+		weaponType.right = weaponType.right === 'cannon' ? 'laser' : 'cannon';
+	}
+	prevLeftSwitch = leftSwitchDown;
+	prevRightSwitch = rightSwitchDown;
 
-        // Firing: triggers or Z/X keys fire respective cannons
-        const leftTriggerDown = !!(
-                controllers.left &&
-                controllers.left.gamepad &&
-                ((typeof controllers.left.gamepad.getButton === 'function' &&
+	// Firing: triggers or Z/X keys fire respective cannons
+	const leftTriggerDown = !!(
+		controllers.left &&
+		controllers.left.gamepad &&
+		((typeof controllers.left.gamepad.getButton === 'function' &&
 			controllers.left.gamepad.getButton(XR_BUTTONS.TRIGGER)) ||
 			(typeof controllers.left.gamepad.getButtonPressed === 'function' &&
 				controllers.left.gamepad.getButtonPressed(XR_BUTTONS.TRIGGER)) ||
@@ -447,85 +466,85 @@ if (enemyGroup && enemyGeo && enemyMats) {
 				controllers.right.gamepad.gamepad.buttons &&
 				controllers.right.gamepad.gamepad.buttons[0]?.pressed))
 	);
-        const leftFiring = leftTriggerDown || keyState.left;
-        const rightFiring = rightTriggerDown || keyState.right;
-        const interval = 1 / FIRE_RATE;
+	const leftFiring = leftTriggerDown || keyState.left;
+	const rightFiring = rightTriggerDown || keyState.right;
+	const interval = 1 / FIRE_RATE;
 
-        if (leftFiring && !prevLeftFiring) {
-                leftFireTimer = interval;
-        }
-        if (rightFiring && !prevRightFiring) {
-                rightFireTimer = interval;
-        }
+	if (leftFiring && !prevLeftFiring) {
+		leftFireTimer = interval;
+	}
+	if (rightFiring && !prevRightFiring) {
+		rightFireTimer = interval;
+	}
 
-        if (leftFiring && bulletGeo && bulletGroup && leftCannon) {
-                const isLaser = weaponType.left === 'laser';
-                const mat = isLaser ? laserMat : bulletMat;
-                const buffer = isLaser ? laserBuffer : cannonBuffer;
-                leftFireTimer += delta;
-                while (leftFireTimer >= interval) {
-                        leftFireTimer -= interval;
-                        const start = new THREE.Vector3();
-                        leftCannon.getWorldPosition(start);
-                        const dir = aimTarget.clone().sub(start).normalize();
-                        const mesh = new THREE.Mesh(bulletGeo, mat);
-                        mesh.position.copy(start);
-                        mesh.userData = {
-                                vel: dir.clone().multiplyScalar(BULLET_SPEED),
-                                ttl: BULLET_TTL,
-                        };
-                        if (buffer && audioListener) {
-                                const shot = new THREE.PositionalAudio(audioListener);
-                                shot.setBuffer(buffer);
-                                shot.setRefDistance(2);
-                                shot.setVolume(0.6);
-                                mesh.add(shot);
-                                shot.play();
-                        }
-                        bulletGroup.add(mesh);
-                        bullets.push(mesh);
-                }
-        } else {
-                leftFireTimer = 0;
-        }
+	if (leftFiring && bulletGeo && bulletGroup && leftCannon) {
+		const isLaser = weaponType.left === 'laser';
+		const mat = isLaser ? laserMat : bulletMat;
+		const buffer = isLaser ? laserBuffer : cannonBuffer;
+		leftFireTimer += delta;
+		while (leftFireTimer >= interval) {
+			leftFireTimer -= interval;
+			const start = new THREE.Vector3();
+			leftCannon.getWorldPosition(start);
+			const dir = aimTarget.clone().sub(start).normalize();
+			const mesh = new THREE.Mesh(bulletGeo, mat);
+			mesh.position.copy(start);
+			mesh.userData = {
+				vel: dir.clone().multiplyScalar(BULLET_SPEED),
+				ttl: BULLET_TTL,
+			};
+			if (buffer && audioListener) {
+				const shot = new THREE.PositionalAudio(audioListener);
+				shot.setBuffer(buffer);
+				shot.setRefDistance(2);
+				shot.setVolume(0.6);
+				mesh.add(shot);
+				shot.play();
+			}
+			bulletGroup.add(mesh);
+			bullets.push(mesh);
+		}
+	} else {
+		leftFireTimer = 0;
+	}
 
-        if (rightFiring && bulletGeo && bulletGroup && rightCannon) {
-                const isLaser = weaponType.right === 'laser';
-                const mat = isLaser ? laserMat : bulletMat;
-                const buffer = isLaser ? laserBuffer : cannonBuffer;
-                rightFireTimer += delta;
-                while (rightFireTimer >= interval) {
-                        rightFireTimer -= interval;
-                        const start = new THREE.Vector3();
-                        rightCannon.getWorldPosition(start);
-                        const dir = aimTarget.clone().sub(start).normalize();
-                        const mesh = new THREE.Mesh(bulletGeo, mat);
-                        mesh.position.copy(start);
-                        mesh.userData = {
-                                vel: dir.clone().multiplyScalar(BULLET_SPEED),
-                                ttl: BULLET_TTL,
-                        };
-                        if (buffer && audioListener) {
-                                const shot = new THREE.PositionalAudio(audioListener);
-                                shot.setBuffer(buffer);
-                                shot.setRefDistance(2);
-                                shot.setVolume(0.6);
-                                mesh.add(shot);
-                                shot.play();
-                        }
-                        bulletGroup.add(mesh);
-                        bullets.push(mesh);
-                }
-        } else {
-                rightFireTimer = 0;
-        }
+	if (rightFiring && bulletGeo && bulletGroup && rightCannon) {
+		const isLaser = weaponType.right === 'laser';
+		const mat = isLaser ? laserMat : bulletMat;
+		const buffer = isLaser ? laserBuffer : cannonBuffer;
+		rightFireTimer += delta;
+		while (rightFireTimer >= interval) {
+			rightFireTimer -= interval;
+			const start = new THREE.Vector3();
+			rightCannon.getWorldPosition(start);
+			const dir = aimTarget.clone().sub(start).normalize();
+			const mesh = new THREE.Mesh(bulletGeo, mat);
+			mesh.position.copy(start);
+			mesh.userData = {
+				vel: dir.clone().multiplyScalar(BULLET_SPEED),
+				ttl: BULLET_TTL,
+			};
+			if (buffer && audioListener) {
+				const shot = new THREE.PositionalAudio(audioListener);
+				shot.setBuffer(buffer);
+				shot.setRefDistance(2);
+				shot.setVolume(0.6);
+				mesh.add(shot);
+				shot.play();
+			}
+			bulletGroup.add(mesh);
+			bullets.push(mesh);
+		}
+	} else {
+		rightFireTimer = 0;
+	}
 
-        prevLeftFiring = leftFiring;
-        prevRightFiring = rightFiring;
+	prevLeftFiring = leftFiring;
+	prevRightFiring = rightFiring;
 
-        for (let i = bullets.length - 1; i >= 0; i--) {
-                const b = bullets[i];
-                b.userData.ttl -= delta;
+	for (let i = bullets.length - 1; i >= 0; i--) {
+		const b = bullets[i];
+		b.userData.ttl -= delta;
 		if (b.userData.ttl <= 0) {
 			bulletGroup.remove(b);
 			bullets.splice(i, 1);
@@ -533,6 +552,17 @@ if (enemyGroup && enemyGeo && enemyMats) {
 		}
 		const deltaMove = b.userData.vel.clone().multiplyScalar(delta);
 		b.position.add(deltaMove);
+	}
+	for (let i = explosions.length - 1; i >= 0; i--) {
+		const ex = explosions[i];
+		ex.userData.ttl -= delta;
+		const s = ex.scale.x + ex.userData.growth * delta;
+		ex.scale.setScalar(s);
+		ex.material.opacity = (ex.userData.ttl / EXPLOSION_TTL) * 0.7;
+		if (ex.userData.ttl <= 0) {
+			explosionGroup.remove(ex);
+			explosions.splice(i, 1);
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- Spawn large transparent fireball when an enemy is destroyed
- Expand and fade the explosion over time for a more dramatic effect

## Testing
- `npx prettier --write src/index.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc5c077a30832f91813217e9a6a13d