### PR TITLE
Add basic local multiplayer stub

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,6 +9,7 @@ import * as THREE from 'three';
 import { XR_AXES, XR_BUTTONS } from 'gamepad-wrapper';
 import { Text } from 'troika-three-text';
 import { init } from './init.js';
+import { initMultiplayer } from './multiplayer.js';
 
 let playerPosText = null;
 let playerRotText = null;
@@ -228,6 +229,7 @@ function setupScene({ scene, camera }) {
 	audioLoader.load('assets/laser.ogg', (buffer) => {
 		laserBuffer = buffer;
 	});
+	initMultiplayer(scene, camera);
 }
 
 const DEADZONE = 0.15;

--- a/src/multiplayer.js
+++ b/src/multiplayer.js
@@ -1,0 +1,27 @@
+import * as THREE from 'three';
+
+const SIGNALING_SERVER_URL = 'ws://localhost:8082';
+const remotePlayers = {};
+
+export function initMultiplayer(scene, camera) {
+	const socket = new WebSocket(SIGNALING_SERVER_URL);
+
+	socket.addEventListener('open', () => {
+		socket.send(JSON.stringify({ type: 'join' }));
+	});
+
+	socket.addEventListener('message', (event) => {
+		const msg = JSON.parse(event.data);
+		if (msg.type === 'spawn' && !remotePlayers[msg.id]) {
+			const mesh = new THREE.Mesh(
+				new THREE.BoxGeometry(0.3, 0.3, 0.3),
+				new THREE.MeshStandardMaterial({ color: 0x00ff00 }),
+			);
+			const spawnPos = camera.position.clone();
+			spawnPos.x += 1;
+			mesh.position.copy(spawnPos);
+			scene.add(mesh);
+			remotePlayers[msg.id] = mesh;
+		}
+	});
+}


### PR DESCRIPTION
## Summary
- import and invoke a new multiplayer bootstrap in scene setup
- stub multiplayer module connects via WebSocket and spawns a second player next to the host

## Testing
- `npx prettier --write src/index.js src/multiplayer.js`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68bc77c25d54832f9c33cf1c1c6d9901